### PR TITLE
使われていないimport文を削除

### DIFF
--- a/codes/chapter18-3/henango/server/worker.py
+++ b/codes/chapter18-3/henango/server/worker.py
@@ -10,7 +10,6 @@ import settings
 from henango.http.request import HTTPRequest
 from henango.http.response import HTTPResponse
 from henango.urls.resolver import URLResolver
-from urls import url_patterns
 
 
 class Worker(Thread):


### PR DESCRIPTION
お世話になっております。

こちらのworker.pyの`from urls import url_patterns`は使われていますでしょうか？
直後の[worker.py](https://github.com/bigen1925/introduction-to-web-application-with-python/blob/main/codes/chapter18-4/henango/server/worker.py)では削除されているようなので削除いたしました。
import文が意図して残されている場合は、お手数ですがPRのクローズをお願いいたしますｍ

